### PR TITLE
Make +mice+ a hash table.

### DIFF
--- a/common.lisp
+++ b/common.lisp
@@ -66,14 +66,12 @@
 ;;----------------------------------------------------------------------
 
 
-(defvar +mice+ (make-array 1 :element-type '(or null mouse)
-                           :adjustable t :fill-pointer 0))
+(defvar +mice+ (make-hash-table :size 1))
 
 (defun mouse (&optional (n 0))
-  (when (> (1+ n) (length +mice+))
-    (adjust-array +mice+ (1+ n) :fill-pointer (1+ n) :initial-element nil)
-    (setf (aref +mice+ n) (make-mouse)))
-  (aref +mice+ n))
+  (unless (gethash n +mice+)
+    (setf (gethash n +mice+) (make-mouse)))
+  (gethash n +mice+))
 
 (defun mouse-down-p (index &optional (mouse (mouse 0)))
   (mouse-button mouse index))


### PR DESCRIPTION
My laptop's touchscreen apparently gets assigned mouse ID 2^32-1, which causes a very large allocation if I accidentally touch my CEPL window. I'm not sure if this change is appropriate for merging, if not I'll just use it locally, but I figured I'd put it here.